### PR TITLE
feat(roster): swap Meat CHA for Outside Prayer on Mobile team

### DIFF
--- a/app/(public)/roster-builder/roster-template.ts
+++ b/app/(public)/roster-builder/roster-template.ts
@@ -130,7 +130,6 @@ export const DEFAULT_ROSTER_TEMPLATE: TemplateCategory[] = [
       { role: CHARole.HEAD_DINING, required: true },
       { role: CHARole.DINING, required: true },
       { role: CHARole.DINING, required: true },
-      { role: CHARole.MEAT, required: true },
     ],
   },
   {
@@ -144,6 +143,7 @@ export const DEFAULT_ROSTER_TEMPLATE: TemplateCategory[] = [
       { role: CHARole.GOPHER, required: true },
       { role: CHARole.MEDIC, required: true },
       { role: CHARole.SMOKER, required: true },
+      { role: CHARole.OUTSIDE_PRAYER, required: true },
     ],
   },
 ]

--- a/docs/cha-roles.md
+++ b/docs/cha-roles.md
@@ -88,21 +88,21 @@ Rollos (prepared talks) are assigned to specific roles and tracked in `weekend_r
 | --------------- | ------------------- |
 | **Head Dining** | _TODO: description_ |
 | **Dining**      | _TODO: description_ |
-| **Meat**        | _TODO: description_ |
 | **Smoker**      | _TODO: description_ |
 
 ## Support & Operations
 
-| Role            | Description                                              |
-| --------------- | -------------------------------------------------------- |
-| **Head Mobile** | _TODO: description_                                      |
-| **Mobile**      | _TODO: description_                                      |
-| **Escort**      | _TODO: description_                                      |
-| **Floater**     | _TODO: description_                                      |
-| **Roster**      | _TODO: description_                                      |
-| **Gopher**      | _TODO: description_                                      |
-| **Medic**       | _TODO: description_                                      |
-| **Rover**       | _TODO: description (note: may be removed in the future)_ |
+| Role               | Description                                              |
+| ------------------ | -------------------------------------------------------- |
+| **Head Mobile**    | _TODO: description_                                      |
+| **Mobile**         | _TODO: description_                                      |
+| **Escort**         | _TODO: description_                                      |
+| **Floater**        | _TODO: description_                                      |
+| **Roster**         | _TODO: description_                                      |
+| **Gopher**         | _TODO: description_                                      |
+| **Medic**          | _TODO: description_                                      |
+| **Outside Prayer** | _TODO: description_                                      |
+| **Rover**          | _TODO: description (note: may be removed in the future)_ |
 
 ---
 

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -218,6 +218,7 @@ const CHA_ROLE_PERMISSIONS: Readonly<Record<CHARole, readonly Permission[]>> = {
     Permission.READ_CANDIDATE_MARITAL_STATUS,
   ],
   [CHARole.SMOKER]: [],
+  [CHARole.OUTSIDE_PRAYER]: [],
   [CHARole.ROVER]: [],
 } as const
 

--- a/lib/weekend/types.ts
+++ b/lib/weekend/types.ts
@@ -139,6 +139,7 @@ export enum CHARole {
   GOPHER = 'Gopher',
   MEDIC = 'Medic',
   SMOKER = 'Smoker',
+  OUTSIDE_PRAYER = 'Outside Prayer',
 
   // todo: we might take this position out in the future
   ROVER = 'Rover',


### PR DESCRIPTION
Removes the Meat slot from the Dining & Food roster template and adds a
new Outside Prayer CHA role under Mobile. Existing Meat assignments in
the database are preserved (enum value kept) so legacy rosters still
resolve. Outside Prayer mirrors Head Prayer / Prayer permissions
(currently none).