### PR TITLE
feat(dashboard): add Sign Up to Serve button linking to secuela sign-in

### DIFF
--- a/app/(public)/home/dashboard.tsx
+++ b/app/(public)/home/dashboard.tsx
@@ -3,6 +3,7 @@ import {
   BookOpen,
   DollarSign,
   File,
+  HandHeart,
   UserPlus,
   CheckCircle,
   CalendarDays,
@@ -76,6 +77,14 @@ export function Dashboard({ user, prayerWheelUrl }: DashboardProps) {
           >
             <UserPlus className="w-10 h-10" />
             <span className="text-lg font-semibold">Sponsor a Candidate</span>
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full h-52 flex flex-col items-center justify-center gap-2"
+            href="/secuela-signin"
+          >
+            <HandHeart className="w-10 h-10" />
+            <span className="text-lg font-semibold">Sign Up to Serve</span>
           </Button>
           {!isNil(prayerWheelUrl) && (
             <Button


### PR DESCRIPTION
Adds a dashboard action tile matching the Sponsor a Candidate button so
community members can tap through to /secuela-signin. The QR generator
already exposes that path, enabling admins to print a scannable handout.