### PR TITLE
Fix roster builder date off-by-one; add generic date helpers

### DIFF
--- a/app/(public)/roster-builder/weekend-picker.tsx
+++ b/app/(public)/roster-builder/weekend-picker.tsx
@@ -6,8 +6,8 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import type { Weekend } from '@/lib/weekend/types'
 import { WeekendType } from '@/lib/weekend/types'
+import { formatDateRange } from '@/lib/utils'
 import { isNil } from 'lodash'
-import { format } from 'date-fns'
 
 type WeekendGroup = {
   number: number | null
@@ -29,12 +29,6 @@ function groupByNumber(weekends: Weekend[]): WeekendGroup[] {
   return Array.from(map.values()).sort(
     (a, b) => (b.number ?? 0) - (a.number ?? 0)
   )
-}
-
-function formatDateRange(start: string, end: string): string {
-  const s = new Date(start)
-  const e = new Date(end)
-  return `${format(s, 'MMM d')} – ${format(e, 'MMM d, yyyy')}`
 }
 
 function WeekendCard({ weekend }: { weekend: Weekend }) {
@@ -72,7 +66,9 @@ function WeekendCard({ weekend }: { weekend: Weekend }) {
 
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4">
             <Calendar className="h-3 w-3 shrink-0" />
-            <span>{formatDateRange(weekend.start_date, weekend.end_date)}</span>
+            <span>
+              {formatDateRange(weekend.start_date, weekend.end_date)}
+            </span>
           </div>
 
           <span className="inline-flex items-center gap-1.5 text-sm font-medium text-primary transition-colors group-hover:text-primary/80">

--- a/app/admin/weekends/components/WeekendCard.tsx
+++ b/app/admin/weekends/components/WeekendCard.tsx
@@ -2,28 +2,12 @@
 
 import { Alert } from '@/components/ui/alert'
 import { Typography } from '@/components/ui/typography'
-import { capitalize, cn, toLocalDateFromISO } from '@/lib/utils'
+import { capitalize, cn, formatDateRange } from '@/lib/utils'
 import type { Weekend } from '@/lib/weekend/types'
-import { formatDateLabel } from '@/lib/weekend/scheduling'
 import Link from 'next/link'
-import { isNil } from 'lodash'
 
 interface WeekendCardProps {
   weekend: Weekend
-}
-
-const formatDateRange = (start?: string | null, end?: string | null) => {
-  const startDate = toLocalDateFromISO(start)
-  const endDate = toLocalDateFromISO(end)
-
-  if (isNil(startDate) || isNil(endDate)) {
-    return 'Dates TBD'
-  }
-
-  const startLabel = formatDateLabel(startDate, { year: undefined })
-  const endLabel = formatDateLabel(endDate)
-
-  return `${startLabel} - ${endLabel}`
 }
 
 export function WeekendCard({ weekend }: WeekendCardProps) {

--- a/components/navbar/navbar-server.tsx
+++ b/components/navbar/navbar-server.tsx
@@ -5,6 +5,7 @@ import { Permission } from '@/lib/security'
 import { getActiveWeekends } from '@/services/weekend'
 import { isOk } from '@/lib/results'
 import { WeekendType } from '@/lib/weekend/types'
+import { formatDate } from '@/lib/utils'
 import { isNil } from 'lodash'
 
 // Icon names that map to lucide-react icons in the client component
@@ -62,15 +63,11 @@ async function getNavElements(): Promise<NavElement[]> {
     const mensWeekend = weekends[WeekendType.MENS]
     const womensWeekend = weekends[WeekendType.WOMENS]
 
-    // Format dates for display
-    const formatDate = (date: Date) =>
-      date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-
     const mensDateStr = !isNil(mensWeekend)
-      ? `Men's: ${formatDate(new Date(mensWeekend.start_date))}`
+      ? `Men's: ${formatDate(mensWeekend.start_date, { year: undefined })}`
       : null
     const womensDateStr = !isNil(womensWeekend)
-      ? `Women's: ${formatDate(new Date(womensWeekend.start_date))}`
+      ? `Women's: ${formatDate(womensWeekend.start_date, { year: undefined })}`
       : null
 
     const dateDescription = [mensDateStr, womensDateStr]

--- a/components/ui/editable-date-field.tsx
+++ b/components/ui/editable-date-field.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { format } from 'date-fns'
 import { Typography } from '@/components/ui/typography'
 import { InlineDateField } from '@/components/ui/inline-date-field'
+import { formatDate } from '@/lib/utils'
 import { isNil } from 'lodash'
 import { Pencil } from 'lucide-react'
 
@@ -25,7 +25,9 @@ export function EditableDateField({
   startYear,
   endYear,
 }: EditableDateFieldProps) {
-  const displayValue = isNil(value) ? emptyText : format(new Date(value), 'PPP')
+  const displayValue = isNil(value)
+    ? emptyText
+    : formatDate(value, { month: 'long' })
 
   return (
     <div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -53,30 +53,68 @@ export type FormattedDateTime =
     }
   | string
 
-/**
- * Formats a date-only string (YYYY-MM-DD or datetime stored as midnight UTC).
- * Use this for weekend start/end dates where only the date matters, not the time.
- * Does NOT apply timezone conversion to avoid date shifting.
- */
-export const formatDateOnly = (dateString: string | null): string => {
-  if (isNil(dateString) || dateString === '') return 'Date TBD'
-
-  try {
-    const date = toLocalDateFromISO(dateString)
-    if (isNil(date)) {
-      return 'Invalid Date'
-    }
-
-    return date.toLocaleDateString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    })
-  } catch {
-    return 'Invalid Date'
-  }
+const DEFAULT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
 }
+
+/**
+ * Formats a date-only value (e.g. "2026-09-03") for display — no time, no
+ * timezone conversion. This is the default helper for rendering any date column.
+ *
+ * Date-only columns (start_date, end_date, date_of_birth, ...) represent a
+ * calendar day, not an instant. Parsing them with `new Date()` interprets the
+ * string as UTC midnight, which renders a day early for any viewer behind UTC
+ * (e.g. all US timezones) — the classic off-by-one. Routing through
+ * `toLocalDateFromISO` builds the date in local time and avoids the shift.
+ *
+ * For real timestamps where the clock time matters (event datetimes), use
+ * `formatDateTime` instead, which applies an explicit timezone.
+ *
+ * @example formatDate('2026-09-03') // "Sep 3, 2026"
+ * @example formatDate('2026-09-03', { year: undefined }) // "Sep 3"
+ * @example formatDate('2026-09-03', { weekday: 'long', month: 'long' }) // "Thursday, September 3, 2026"
+ */
+export const formatDate = (
+  dateString?: string | null,
+  options?: Intl.DateTimeFormatOptions
+): string => {
+  const date = toLocalDateFromISO(dateString)
+  if (isNil(date)) return 'Date TBD'
+
+  return date.toLocaleDateString('en-US', {
+    ...DEFAULT_DATE_FORMAT,
+    ...options,
+  })
+}
+
+/**
+ * Formats a date-only range (e.g. "Sep 3 - Sep 6, 2026"). The start label omits
+ * the year by default to avoid repetition; pass `options` to customize both
+ * ends. Returns 'Dates TBD' if either side is missing or invalid.
+ */
+export const formatDateRange = (
+  start?: string | null,
+  end?: string | null,
+  options?: Intl.DateTimeFormatOptions
+): string => {
+  if (isNil(toLocalDateFromISO(start)) || isNil(toLocalDateFromISO(end))) {
+    return 'Dates TBD'
+  }
+
+  const startLabel = formatDate(start, { year: undefined, ...options })
+  const endLabel = formatDate(end, options)
+
+  return `${startLabel} - ${endLabel}`
+}
+
+/**
+ * Long-form date-only formatter (e.g. "Thursday, September 3, 2026").
+ * Thin wrapper over {@link formatDate}; prefer `formatDate` for new code.
+ */
+export const formatDateOnly = (dateString: string | null): string =>
+  formatDate(dateString, { weekday: 'long', month: 'long' })
 
 /**
  * Formats a datetime string with timezone conversion to Chicago time.


### PR DESCRIPTION
The roster builder weekend picker formatted weekend dates with
new Date(start_date) + date-fns format(). Since start_date/end_date are
date-only strings (e.g. "2026-09-03"), new Date() parses them as UTC
midnight and format() renders them in local time, showing a day early
for viewers behind UTC (prod). The admin weekends page avoided this by
parsing via toLocalDateFromISO.

Add generic, reusable date-only formatters in lib/utils (formatDate,
formatDateRange) built on toLocalDateFromISO so any date column renders
in the correct local calendar day, and route the roster builder, admin
WeekendCard, navbar, and editable date field through them. formatDateOnly
is now a thin wrapper over formatDate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QLg7Yf8fm294Ae1xMrL2cm