### PR TITLE
Make payment owner editable on candidate review page

### DIFF
--- a/app/(public)/review-candidates/[candidate_id]/components/SponsorInformationSection.tsx
+++ b/app/(public)/review-candidates/[candidate_id]/components/SponsorInformationSection.tsx
@@ -10,6 +10,8 @@ import * as Results from '@/lib/results'
 import { toastError } from '@/lib/toast-error'
 import type { Database } from '@/database.types'
 import { useCallback } from 'react'
+import { Pencil } from 'lucide-react'
+import { PaymentOwnerForm } from '@/app/(public)/review-candidates/components/PaymentOwnerForm'
 
 type SponsorshipInfoUpdate =
   Database['public']['Tables']['candidate_sponsorship_info']['Update']
@@ -152,7 +154,23 @@ export function SponsorInformationSection({
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <ReadOnlyField label="Payment Owner" value={paymentOwnerDisplay} />
+        {canEdit ? (
+          <div>
+            <Typography
+              variant="small"
+              className="text-muted-foreground flex items-center gap-1"
+            >
+              Payment Owner
+              <Pencil className="h-3 w-3" />
+            </Typography>
+            <PaymentOwnerForm
+              candidateId={candidate.id}
+              initialPaymentOwner={sponsorshipInfo?.payment_owner}
+            />
+          </div>
+        ) : (
+          <ReadOnlyField label="Payment Owner" value={paymentOwnerDisplay} />
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- The Payment Owner field on the candidate review page (`/review-candidates/[candidate_id]`) was rendered as a plain read-only value, unlike every other field in the Sponsor Information section which uses `EditableField`.
- A `PaymentOwnerForm` component (sponsor/candidate radio toggle backed by `updateCandidatePaymentOwner`) already existed but was never wired into any page — it was dead code.
- Wired `PaymentOwnerForm` into `SponsorInformationSection`, gated behind the section's existing `canEdit` prop, matching the styling/affordance (label + pencil icon) used by the other editable fields.

## Test plan
- [x] `yarn build` — compiles and type-checks successfully (build only fails later on an unrelated missing `STRIPE_SECRET_KEY` env var when collecting page data for the Stripe webhook route)
- [x] `yarn lint` — no new errors (one pre-existing, unrelated warning in `data-table.tsx`)
- [ ] Manually verify in the browser that toggling Payment Owner on the candidate review page persists the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qj9GPei3srmz73pbpUdLLx)_