### PR TITLE
fix(ui): standardize date display on en-US MM/DD/YYYY

### DIFF
--- a/app/(public)/candidate/[candidateId]/forms/candidate-forms.tsx
+++ b/app/(public)/candidate/[candidateId]/forms/candidate-forms.tsx
@@ -32,7 +32,7 @@ import { CampWaiverText } from '@/components/forms/camp-waiver-text'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { addCandidateInfo } from '@/actions/candidates'
 import { isErr } from '@/lib/results'
-import { calculateAge } from '@/lib/utils'
+import { calculateAge, formatDateNumeric } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
 import { isDevMode } from '@/lib/dev-mode'
 import { CANDIDATE_FORM_TEST_DATA } from './candidate-forms.helpers'
@@ -693,7 +693,7 @@ export function CandidateForms({
               <div className="space-y-1">
                 <Label className="text-muted-foreground">Date</Label>
                 <div className="h-10 flex items-center px-3 border rounded-md bg-muted text-muted-foreground">
-                  {new Date().toLocaleDateString()}
+                  {formatDateNumeric(new Date())}
                 </div>
               </div>
             </div>

--- a/app/(public)/review-candidates/config/columns.tsx
+++ b/app/(public)/review-candidates/config/columns.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatTimestampDate } from '@/lib/utils'
 import type { ColumnDef, FilterFn, Row, SortingFn } from '@tanstack/react-table'
 import type { HydratedCandidate, CandidateStatus } from '@/lib/candidates/types'
 import { DataTableColumnHeader } from '@/components/ui/data-table'
@@ -134,7 +135,7 @@ export function getCandidateReviewColumns(
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Submitted" />
       ),
-      cell: ({ getValue }) => new Date(getValue<string>()).toLocaleDateString(),
+      cell: ({ getValue }) => formatTimestampDate(getValue<string>()),
       meta: {
         showOnMobile: true,
         mobileLabel: 'Submitted',

--- a/app/admin/community-board/components/meeting-minutes-table.tsx
+++ b/app/admin/community-board/components/meeting-minutes-table.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatTimestampDate } from '@/lib/utils'
 import type { FileObject } from '@supabase/storage-js'
 import type {
   MeetingMinuteFile,
@@ -174,13 +175,7 @@ export function MeetingMinutesTable({
                       {file.name}
                     </div>
                   </TableCell>
-                  <TableCell>
-                    {file.created_at !== undefined &&
-                    file.created_at !== null &&
-                    file.created_at !== ''
-                      ? new Date(file.created_at).toLocaleDateString()
-                      : '-'}
-                  </TableCell>
+                  <TableCell>{formatTimestampDate(file.created_at)}</TableCell>
                   <TableCell className="text-muted-foreground">
                     {file.location ?? '-'}
                   </TableCell>

--- a/components/file-list.tsx
+++ b/components/file-list.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatTimestampDate } from '@/lib/utils'
 import { useState } from 'react'
 import Link from 'next/link'
 import { isNil } from 'lodash'
@@ -57,11 +58,6 @@ export function FileList({ items, currentBucket, currentPath }: FileListProps) {
     return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${sizes[i]}`
   }
 
-  const formatDate = (dateString?: string) => {
-    if (isNil(dateString)) return '-'
-    return new Date(dateString).toLocaleDateString()
-  }
-
   return (
     <>
       <div className="divide-y">
@@ -103,7 +99,7 @@ export function FileList({ items, currentBucket, currentPath }: FileListProps) {
                     <div className="font-medium truncate">{item.name}</div>
                     <div className="text-sm text-muted-foreground">
                       {formatFileSize(item.size)} •{' '}
-                      {formatDate(item.updated_at)}
+                      {formatTimestampDate(item.updated_at)}
                     </div>
                   </div>
                 )}

--- a/components/file-management/FileTable.tsx
+++ b/components/file-management/FileTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatTimestampDate } from '@/lib/utils'
 import { useState, useEffect } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { isNil } from 'lodash'
@@ -114,11 +115,7 @@ export function FileTable({ files: initialFiles, folderName }: FileTableProps) {
                     ? `${(file.metadata.size / 1024).toFixed(1)} KB`
                     : '-'}
                 </TableCell>
-                <TableCell>
-                  {!isNil(file.updated_at)
-                    ? new Date(file.updated_at).toLocaleDateString()
-                    : '-'}
-                </TableCell>
+                <TableCell>{formatTimestampDate(file.updated_at)}</TableCell>
                 <TableCell className="sticky right-0 bg-background text-right border-l">
                   <div onClick={(e) => e.stopPropagation()}>
                     <TooltipProvider>

--- a/components/file-management/SortableFileTable.tsx
+++ b/components/file-management/SortableFileTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatTimestampDate } from '@/lib/utils'
 import { useEffect, useState } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { FileObject } from '@supabase/storage-js'
@@ -112,12 +113,7 @@ export function SortableFileTable({
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Last Modified" />
       ),
-      cell: ({ row }) =>
-        row.original.updated_at !== undefined &&
-        row.original.updated_at !== null &&
-        row.original.updated_at !== ''
-          ? new Date(row.original.updated_at).toLocaleDateString()
-          : '-',
+      cell: ({ row }) => formatTimestampDate(row.original.updated_at),
       meta: {
         showOnMobile: true,
         mobileLabel: 'Last Modified',

--- a/components/public-files/PublicFileTable.tsx
+++ b/components/public-files/PublicFileTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatTimestampDate } from '@/lib/utils'
 import { createClient } from '@/lib/supabase/client'
 import type { FileObject } from '@supabase/storage-js'
 import { logger } from '@/lib/logger'
@@ -136,9 +137,7 @@ export function PublicFileTable({ files, folderName }: PublicFileTableProps) {
                         : '-'}
                     </TableCell>
                     <TableCell>
-                      {!isNil(file.updated_at)
-                        ? new Date(file.updated_at).toLocaleDateString()
-                        : '-'}
+                      {formatTimestampDate(file.updated_at)}
                     </TableCell>
                     <TableCell className="text-right">
                       <div onClick={(e) => e.stopPropagation()}>

--- a/components/team-forms/camp-waiver-form.tsx
+++ b/components/team-forms/camp-waiver-form.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatDateNumeric } from '@/lib/utils'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
@@ -52,7 +53,7 @@ export function CampWaiverForm({
     },
   })
 
-  const currentDate = new Date().toLocaleDateString()
+  const currentDate = formatDateNumeric(new Date())
 
   const onSubmit = async (data: CampWaiverFormValues) => {
     setIsSubmitting(true)

--- a/components/team-forms/commitment-form-component.tsx
+++ b/components/team-forms/commitment-form-component.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatDateNumeric } from '@/lib/utils'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
@@ -94,7 +95,7 @@ export function CommitmentFormComponent({
     setIsSubmitting(false)
   }
 
-  const currentDate = new Date().toLocaleDateString()
+  const currentDate = formatDateNumeric(new Date())
 
   return (
     <>

--- a/components/team-forms/release-of-claim-form.tsx
+++ b/components/team-forms/release-of-claim-form.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatDateNumeric } from '@/lib/utils'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm, useWatch } from 'react-hook-form'
@@ -83,7 +84,7 @@ export function ReleaseOfClaimForm({
     control: form.control,
     name: 'has_special_needs',
   })
-  const currentDate = new Date().toLocaleDateString()
+  const currentDate = formatDateNumeric(new Date())
 
   const onSubmit = async (data: ReleaseOfClaimFormValues) => {
     setIsSubmitting(true)

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -6,7 +6,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from 'lucide-react'
-import type { DayButton} from 'react-day-picker';
+import type { DayButton } from 'react-day-picker'
 import { DayPicker, getDefaultClassNames } from 'react-day-picker'
 
 import { cn } from '@/lib/utils'
@@ -38,7 +38,7 @@ function Calendar({
       captionLayout={captionLayout}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString('default', { month: 'short' }),
+          date.toLocaleString('en-US', { month: 'short' }),
         ...formatters,
       }}
       classNames={{

--- a/components/ui/date-input.tsx
+++ b/components/ui/date-input.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import { Calendar as CalendarIcon } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { cn, formatDateNumeric } from '@/lib/utils'
 import { isNil } from 'lodash'
 
 /**
@@ -67,14 +67,6 @@ export interface DateInputProps {
   required?: boolean
 }
 
-function formatDisplay(d: Date): string {
-  return d.toLocaleDateString('en-US', {
-    month: '2-digit',
-    day: '2-digit',
-    year: 'numeric',
-  })
-}
-
 function DateInput({
   date,
   onDateChange,
@@ -115,10 +107,10 @@ function DateInput({
       return 'Invalid date'
     }
     if (!isNil(minDate) && parsed < minDate) {
-      return `Date must be after ${formatDisplay(minDate)}`
+      return `Date must be after ${formatDateNumeric(minDate)}`
     }
     if (!isNil(maxDate) && parsed > maxDate) {
-      return `Date must be before ${formatDisplay(maxDate)}`
+      return `Date must be before ${formatDateNumeric(maxDate)}`
     }
     return null
   }
@@ -166,7 +158,7 @@ function DateInput({
   const displayValue = isFocused
     ? formatDateString(digits)
     : !isNil(date)
-      ? formatDisplay(date)
+      ? formatDateNumeric(date)
       : formatDateString(digits)
 
   return (

--- a/components/ui/editable-date-field.tsx
+++ b/components/ui/editable-date-field.tsx
@@ -2,7 +2,7 @@
 
 import { Typography } from '@/components/ui/typography'
 import { InlineDateField } from '@/components/ui/inline-date-field'
-import { formatDate } from '@/lib/utils'
+import { formatDate, NUMERIC_DATE_FORMAT } from '@/lib/utils'
 import { isNil } from 'lodash'
 import { Pencil } from 'lucide-react'
 
@@ -27,7 +27,7 @@ export function EditableDateField({
 }: EditableDateFieldProps) {
   const displayValue = isNil(value)
     ? emptyText
-    : formatDate(value, { month: 'long' })
+    : formatDate(value, NUMERIC_DATE_FORMAT)
 
   return (
     <div>

--- a/components/ui/inline-date-field.tsx
+++ b/components/ui/inline-date-field.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import * as React from 'react'
-import { cn } from '@/lib/utils'
+import {
+  cn,
+  formatDateNumeric,
+  toISODateString,
+  toLocalDateFromISO,
+} from '@/lib/utils'
 import { isNil } from 'lodash'
 import { DateInput } from '@/components/ui/date-input'
 
@@ -25,12 +30,14 @@ export function InlineDateField({
   const [isEditing, setIsEditing] = React.useState(false)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
 
-  const dateValue = !isNil(value) ? new Date(value) : undefined
+  // `new Date(value)` would read a date-only string as UTC midnight and render
+  // a day early for viewers behind UTC; toLocalDateFromISO builds it locally.
+  const dateValue = toLocalDateFromISO(value) ?? undefined
 
   async function handleDateChange(selectedDate: Date | undefined) {
     if (isNil(selectedDate)) return
 
-    const isoString = selectedDate.toISOString().split('T')[0]
+    const isoString = toISODateString(selectedDate)
     if (isoString !== value) {
       setIsSubmitting(true)
       try {
@@ -43,13 +50,7 @@ export function InlineDateField({
   }
 
   if (!isEditing) {
-    const displayValue = !isNil(dateValue)
-      ? dateValue.toLocaleDateString('en-US', {
-          month: 'long',
-          day: 'numeric',
-          year: 'numeric',
-        })
-      : ''
+    const displayValue = !isNil(dateValue) ? formatDateNumeric(dateValue) : ''
     const isEmpty = isNil(value)
 
     return (

--- a/components/ui/month-picker.tsx
+++ b/components/ui/month-picker.tsx
@@ -106,7 +106,11 @@ export function MonthPickerPopover({
             className
           )}
         >
-          {!isNil(value) ? format(value, 'MMMM yyyy') : <span>{placeholder}</span>}
+          {!isNil(value) ? (
+            format(value, 'MMM yyyy')
+          ) : (
+            <span>{placeholder}</span>
+          )}
           <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
         </Button>
       </PopoverTrigger>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -59,6 +59,9 @@ const DEFAULT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
   year: 'numeric',
 }
 
+/** The community's timezone — all event and record times are shown in CT. */
+export const COMMUNITY_TIMEZONE = 'America/Chicago'
+
 /**
  * The numeric American date format (MM/DD/YYYY) used by every date input
  * component, so a field reads identically whether it is being edited or just
@@ -146,13 +149,13 @@ export const formatDateTime = (datetime: string | null): FormattedDateTime => {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      timeZone: 'America/Chicago',
+      timeZone: COMMUNITY_TIMEZONE,
     })
     const timeStr = date.toLocaleTimeString('en-US', {
       hour: 'numeric',
       minute: '2-digit',
       hour12: true,
-      timeZone: 'America/Chicago',
+      timeZone: COMMUNITY_TIMEZONE,
     })
 
     return { dateStr, timeStr: `${timeStr} CT` }
@@ -170,6 +173,29 @@ export const formatDateTime = (datetime: string | null): FormattedDateTime => {
  */
 export const formatDateNumeric = (date: Date): string =>
   date.toLocaleDateString('en-US', NUMERIC_DATE_FORMAT)
+
+/**
+ * Formats a timestamp (a real instant, e.g. `created_at`/`updated_at`) as the
+ * MM/DD/YYYY calendar day it fell on in community time. Returns '-' when the
+ * value is missing or unparseable, which is what table cells want.
+ *
+ * Distinct from {@link formatDate}, which is for date-only columns: this parses
+ * the full instant rather than taking the literal date portion, so a file
+ * uploaded at 02:00 UTC is reported on the previous CT day, as it should be.
+ *
+ * @example formatTimestampDate('2026-09-03T14:30:00Z') // "09/03/2026"
+ */
+export const formatTimestampDate = (datetime?: string | null): string => {
+  if (isNil(datetime) || datetime === '') return '-'
+
+  const date = new Date(datetime)
+  if (isNaN(date.getTime())) return '-'
+
+  return date.toLocaleDateString('en-US', {
+    ...NUMERIC_DATE_FORMAT,
+    timeZone: COMMUNITY_TIMEZONE,
+  })
+}
 
 /**
  * Serializes a `Date` to a "YYYY-MM-DD" string using its local calendar day.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -60,6 +60,18 @@ const DEFAULT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
 }
 
 /**
+ * The numeric American date format (MM/DD/YYYY) used by every date input
+ * component, so a field reads identically whether it is being edited or just
+ * displayed. Pass it to {@link formatDate} for ISO strings, or use
+ * {@link formatDateNumeric} for a `Date` you already hold.
+ */
+export const NUMERIC_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: '2-digit',
+  day: '2-digit',
+  year: 'numeric',
+}
+
+/**
  * Formats a date-only value (e.g. "2026-09-03") for display — no time, no
  * timezone conversion. This is the default helper for rendering any date column.
  *
@@ -147,6 +159,31 @@ export const formatDateTime = (datetime: string | null): FormattedDateTime => {
   } catch {
     return 'Invalid Date'
   }
+}
+
+/**
+ * Formats a `Date` as MM/DD/YYYY. Use this for values already held as `Date`
+ * (date inputs, pickers); for date-only ISO strings prefer
+ * `formatDate(value, NUMERIC_DATE_FORMAT)`, which avoids the UTC off-by-one.
+ *
+ * @example formatDateNumeric(new Date(2026, 8, 3)) // "09/03/2026"
+ */
+export const formatDateNumeric = (date: Date): string =>
+  date.toLocaleDateString('en-US', NUMERIC_DATE_FORMAT)
+
+/**
+ * Serializes a `Date` to a "YYYY-MM-DD" string using its local calendar day.
+ *
+ * `toISOString().split('T')[0]` looks equivalent but converts to UTC first, so
+ * a local midnight in any UTC-positive zone serializes to the previous day.
+ * Reading those values back through `toLocalDateFromISO` is what keeps a
+ * date-only round trip stable.
+ */
+export const toISODateString = (date: Date): string => {
+  const year = String(date.getFullYear()).padStart(4, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 export const setDatetimeToMidnight = (date: Date) => {

--- a/lib/weekend/scheduling.ts
+++ b/lib/weekend/scheduling.ts
@@ -1,7 +1,11 @@
 import { isNil } from 'lodash'
 import { formatWeekendTitle } from '.'
 import type { WeekendGroupWithId, Weekend } from '@/lib/weekend/types'
-import { setDatetimeToMidnight, toLocalDateFromISO } from '@/lib/utils'
+import {
+  setDatetimeToMidnight,
+  toISODateString,
+  toLocalDateFromISO,
+} from '@/lib/utils'
 
 export type DateRange = {
   start: Date
@@ -40,7 +44,7 @@ export const formatDateLabel = (
     ...options,
   })
 
-export const formatDateForApi = (date: Date) => date.toISOString().split('T')[0]
+export const formatDateForApi = (date: Date) => toISODateString(date)
 
 export const getNextThursdayRange = (reference = new Date()): DateRange => {
   const next = setDatetimeToMidnight(reference)


### PR DESCRIPTION
Follows up the timezone standardization in `c0b136b` by making the *format* consistent too. Every date the app renders as a plain calendar day now reads as **MM/DD/YYYY**, pinned to `en-US`.

## Why

Two separate inconsistencies:

1. **Date fields reformatted themselves when clicked.** `DateInput` rendered `09/03/2026`, but the read-only display in `InlineDateField` / `EditableDateField` rendered `September 3, 2026`. Clicking Date of Birth on the candidate review page visibly changed the format.
2. **A dozen call sites used a bare `toLocaleDateString()`**, which follows the *viewer's browser locale* rather than a fixed one. On a device set to a European locale, `09/03` renders as `03/09`. That's worst on the camp waiver and release-of-claim forms, where an ambiguous date sits on a signed legal record.

## Changes

Three shared helpers in `lib/utils.ts`, so there's one place to change this again later:

| Helper | For | Output |
|---|---|---|
| `NUMERIC_DATE_FORMAT` | option set, passed to `formatDate` for ISO strings | `09/03/2026` |
| `formatDateNumeric(date)` | a `Date` you already hold — inputs, pickers | `09/03/2026` |
| `formatTimestampDate(ts)` | instants (`created_at` / `updated_at`) | `09/03/2026`, or `-` |

`formatTimestampDate` is deliberately distinct from `formatDate`: timestamps are real instants, not date-only columns, so it parses the full instant and resolves to the CT calendar day. Taking the literal date portion instead would report a late-evening upload on the following day.

Commits are split so each is reviewable on its own:

- **`5c3233c`** — the four date input components onto one shared format.
- **`eb21146`** — the locale pinning across file tables, meeting minutes, candidate columns, team/candidate forms, and the calendar month dropdown.
- **`f2c8592`** — month picker label shortened to `Sep 2026` (month-granularity field, so MM/DD/YYYY doesn't apply).
- **`d4604b6`** — `formatDateForApi` off-by-one, see below.

## Bugs fixed along the way

**`InlineDateField` displayed the wrong day.** `new Date("2026-09-03")` parses as UTC midnight, which is Sept **2** 7:00 PM in Chicago — so the field showed the previous day *and* pre-filled the editor with it. This is exactly the off-by-one `toLocalDateFromISO` was added for; reads now go through it.

**`formatDateForApi` serialized the wrong day.** It built `YYYY-MM-DD` via `toISOString()`, which converts to UTC first, so a local midnight in any UTC-positive zone saved the previous day's weekend dates. Now uses the new `toISODateString`, which reads the local calendar day directly. Harmless in US timezones, but it was a live footgun on the weekend-save path.

## Verification

`npx tsc --noEmit` is clean. `yarn lint` reports only the pre-existing `data-table.tsx` warning, untouched here.

`yarn build` compiles and typechecks successfully but fails collecting page data for `/admin/community-board` — that's `RESEND_API_KEY` being unset in the sandbox, not related to these changes. **Worth a green CI run to confirm** before merging.

## Not changed

Long-form prose dates are deliberately left alone — the homepage weekend hero, weekend roster header, navbar, and event cards still read `Thursday, September 3, 2026`, which is right for those surfaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnSi43qVyJehmi93YiAJub)_