### PR TITLE
Backfill payment_transaction.weekend_id for manual payments

### DIFF
--- a/services/candidates/candidate-service.ts
+++ b/services/candidates/candidate-service.ts
@@ -180,7 +180,7 @@ export async function recordManualCandidatePayment(
     type: 'fee',
     target_type: 'candidate',
     target_id: candidateId,
-    weekend_id: null, // Could be fetched from candidate if needed
+    weekend_id: candidateResult.data.weekend_id,
     payment_intent_id: paymentIntentId,
     gross_amount: paymentAmount,
     payment_method: paymentMethod,

--- a/services/candidates/repository.ts
+++ b/services/candidates/repository.ts
@@ -47,12 +47,12 @@ export const getAllCandidates = async () => {
  */
 export async function findCandidateById(
   id: string
-): Promise<Result<string, { id: string } | null>> {
+): Promise<Result<string, { id: string; weekend_id: string | null } | null>> {
   const supabase = await createClient()
 
   const { data, error } = await supabase
     .from('candidates')
-    .select('id')
+    .select('id, weekend_id')
     .eq('id', id)
     .single()
 

--- a/services/weekend/weekend-service.ts
+++ b/services/weekend/weekend-service.ts
@@ -977,6 +977,14 @@ export async function recordManualPayment(
   paymentOwner: string,
   notes?: string
 ): Promise<Result<string, PaymentTransactionRow>> {
+  // Resolve the member's weekend so the payment is tagged with it
+  const groupMemberResult =
+    await GroupMemberRepository.getGroupMemberById(groupMemberId)
+
+  if (isErr(groupMemberResult)) {
+    return err(`Failed to find group member: ${groupMemberResult.error}`)
+  }
+
   // Generate a manual payment intent ID
   const paymentIntentId = `manual_${Date.now()}_${Math.random().toString(36).substring(7)}`
 
@@ -985,7 +993,7 @@ export async function recordManualPayment(
     type: 'fee',
     target_type: 'weekend_group_member',
     target_id: groupMemberId,
-    weekend_id: null,
+    weekend_id: groupMemberResult.data.weekendId,
     payment_intent_id: paymentIntentId,
     gross_amount: paymentAmount,
     payment_method: paymentMethod,

--- a/supabase/migrations/20260812000000_backfill_payment_transaction_weekend_id.sql
+++ b/supabase/migrations/20260812000000_backfill_payment_transaction_weekend_id.sql
@@ -1,0 +1,36 @@
+-- Backfill payment_transaction.weekend_id for rows recorded without a weekend.
+-- The manual (cash/check) payment flows historically inserted weekend_id = NULL,
+-- which renders as "Unknown" in the admin payments table. Resolve the weekend
+-- from each payment's target.
+
+-- 1. Candidate payments: candidates carry their weekend directly.
+UPDATE payment_transaction pt
+SET weekend_id = c.weekend_id
+FROM candidates c
+WHERE pt.weekend_id IS NULL
+  AND pt.target_type = 'candidate'
+  AND pt.target_id = c.id
+  AND c.weekend_id IS NOT NULL;
+
+-- 2. Legacy weekend_roster payments: roster rows carry their weekend directly.
+UPDATE payment_transaction pt
+SET weekend_id = wr.weekend_id
+FROM weekend_roster wr
+WHERE pt.weekend_id IS NULL
+  AND pt.target_type = 'weekend_roster'
+  AND pt.target_id = wr.id
+  AND wr.weekend_id IS NOT NULL;
+
+-- 3. Group member payments: a group contains both a MENS and a WOMENS weekend,
+-- so pick the one matching the member's gender (mirrors getGroupMemberById in
+-- services/weekend-group-member/repository.ts).
+UPDATE payment_transaction pt
+SET weekend_id = w.id
+FROM weekend_group_members gm
+JOIN users u ON u.id = gm.user_id
+JOIN weekends w
+  ON w.group_id = gm.group_id
+  AND w.type = CASE WHEN u.gender = 'female' THEN 'WOMENS' ELSE 'MENS' END
+WHERE pt.weekend_id IS NULL
+  AND pt.target_type = 'weekend_group_member'
+  AND pt.target_id = gm.id;

--- a/supabase/migrations/20260812000000_backfill_payment_transaction_weekend_id.sql
+++ b/supabase/migrations/20260812000000_backfill_payment_transaction_weekend_id.sql
@@ -30,7 +30,7 @@ FROM weekend_group_members gm
 JOIN users u ON u.id = gm.user_id
 JOIN weekends w
   ON w.group_id = gm.group_id
-  AND w.type = CASE WHEN u.gender = 'female' THEN 'WOMENS' ELSE 'MENS' END
+  AND w.type = (CASE WHEN u.gender = 'female' THEN 'WOMENS' ELSE 'MENS' END)::weekend_type
 WHERE pt.weekend_id IS NULL
   AND pt.target_type = 'weekend_group_member'
   AND pt.target_id = gm.id;


### PR DESCRIPTION
## Summary

This PR resolves a data quality issue where manual payments (cash/check) were recorded without a `weekend_id`, causing them to display as "Unknown" in the admin payments table. The fix backfills existing records and updates the payment recording logic to capture the weekend context.

## Key Changes

- **Migration**: Added `20260812000000_backfill_payment_transaction_weekend_id.sql` to backfill `weekend_id` for existing payment transactions by resolving the weekend from their target records:
  - Candidate payments: resolved from `candidates.weekend_id`
  - Weekend roster payments: resolved from `weekend_roster.weekend_id`
  - Group member payments: resolved by matching the member's gender to the group's weekend type (MENS/WOMENS)

- **Weekend Group Member Payments**: Updated `recordManualPayment()` in `weekend-service.ts` to fetch the group member's weekend and include it when creating the payment transaction (instead of `null`)

- **Candidate Payments**: Updated `recordManualCandidatePayment()` in `candidate-service.ts` to use the candidate's `weekend_id` when creating the payment transaction

- **Repository Enhancement**: Modified `findCandidateById()` in `candidates/repository.ts` to return `weekend_id` alongside the candidate ID to support the above change

## Implementation Details

The group member weekend resolution logic mirrors the existing `getGroupMemberById()` implementation in the codebase, ensuring consistency in how weekends are determined for group members based on their gender.

https://claude.ai/code/session_01SBUE6qhzGezWCkufXi2JWk