### PR TITLE
refactor(weekend): derive weekend labels instead of storing them

### DIFF
--- a/actions/candidates.ts
+++ b/actions/candidates.ts
@@ -17,6 +17,7 @@ import { sendCandidateFormsCompletedEmail } from '@/services/notifications'
 import { logger } from '@/lib/logger'
 import type { WeekendType } from '@/lib/weekend/types'
 import { WeekendStatus, WEEKEND_CANDIDATE_CAPACITY } from '@/lib/weekend/types'
+import { formatWeekendLabelFor } from '@/lib/weekend'
 import type { Database } from '@/database.types'
 import { getCandidateCountByWeekend } from '@/services/candidates/actions'
 import {
@@ -532,14 +533,12 @@ export async function getMoveWeekendOptions(
       weekends.map(async (weekend) => {
         const countResult = await getCandidateCountByWeekend(weekend.id)
         const count = isErr(countResult) ? 0 : countResult.data
-        const number = weekend.weekend_groups?.number
-        const groupLabel = !isNil(number)
-          ? `DTTD #${number}`
-          : (weekend.title ?? 'Weekend')
-        const gender = weekend.type === 'MENS' ? "Men's" : "Women's"
         return {
           weekendId: weekend.id,
-          label: `${groupLabel} ${gender}`,
+          label: formatWeekendLabelFor({
+            number: weekend.weekend_groups?.number,
+            gender: weekend.type,
+          }),
           count,
           capacity: WEEKEND_CANDIDATE_CAPACITY,
           isFull: count >= WEEKEND_CANDIDATE_CAPACITY,

--- a/actions/user-experience.ts
+++ b/actions/user-experience.ts
@@ -1,10 +1,9 @@
 'use server'
 
 import { createClient } from '@/lib/supabase/server'
-import type { Result} from '@/lib/results';
+import type { Result } from '@/lib/results'
 import { err, ok } from '@/lib/results'
-import type {
-  UserExperience} from '@/lib/users/experience';
+import type { UserExperience } from '@/lib/users/experience'
 import {
   calculateExperienceLevel,
   calculateRectorReadyStatus,
@@ -16,7 +15,10 @@ import z from 'zod'
 import { isNil } from 'lodash'
 import type { UserExperienceFormValue } from '@/components/team-forms/schemas'
 import type { UserServiceHistory } from '@/services/master-roster/types'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
+import {
+  formatCommunityWeekendRef,
+  toCommunityWeekendRef,
+} from '@/lib/weekend/weekend-reference'
 
 /**
  * @deprecated - move a version of this function to the master roster service and call that instead.
@@ -125,15 +127,15 @@ export async function upsertUserExperience(
       return err('Missing community or weekend number')
     }
 
-    const weekend_reference = new WeekendReference(
-      entry.community,
-      parseInt(entry.weekend_number)
-    )
+    const weekend_reference = toCommunityWeekendRef({
+      community: entry.community,
+      number: parseInt(entry.weekend_number),
+    })
 
     const payload = {
       user_id: userId,
       cha_role: entry.cha_role, // Enum string
-      weekend_reference: weekend_reference.toString(),
+      weekend_reference: formatCommunityWeekendRef(weekend_reference),
       updated_at: new Date().toISOString(),
       // Ensure weekend_id is null for external
       weekend_id: null,

--- a/app/(public)/home/current-weekend-hero.tsx
+++ b/app/(public)/home/current-weekend-hero.tsx
@@ -15,8 +15,7 @@ import { isUserOnActiveTeam } from '@/lib/users'
 import {
   formatTeamMemberRole,
   formatTeamMemberTitle,
-  formatWeekendTitle,
-  trimWeekendTypeFromTitle,
+  formatWeekendGroupTitle,
 } from '@/lib/weekend'
 import { formatDateRange } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -139,13 +138,7 @@ function WeekendRow({ label, weekend, candidateCount }: WeekendRowProps) {
 }
 
 function getGroupTitle(mensWeekend: Weekend, womensWeekend: Weekend): string {
-  const number = mensWeekend.number ?? womensWeekend.number
-  if (!isNil(number)) {
-    return `${COMMUNITY_NAME} #${number}`
-  }
-
-  // Fall back to the weekend title with the Mens/Womens prefix stripped
-  return trimWeekendTypeFromTitle(formatWeekendTitle(mensWeekend)).trim()
+  return formatWeekendGroupTitle(mensWeekend.number ?? womensWeekend.number)
 }
 
 function EmptyWeekendHero() {

--- a/app/(public)/sponsor/SponsorForm.tsx
+++ b/app/(public)/sponsor/SponsorForm.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation'
 import { sendSponsorshipNotificationEmail } from '@/services/notifications'
 import * as Results from '@/lib/results'
 import { isNil } from 'lodash'
+import { formatWeekendTitle } from '@/lib/weekend'
 import { useSession } from '@/components/auth/session-provider'
 import { createCandidateWithSponsorshipInfo } from '@/actions/candidates'
 import { useWeekends } from '@/hooks/useWeekends'
@@ -262,16 +263,16 @@ export function SponsorForm() {
                           <SelectContent>
                             {!isNil(weekends?.MENS) && (
                               <SelectItem value={weekends.MENS.id}>
-                                Men&apos;s Weekend -{' '}
-                                {weekends.MENS.title ??
-                                  `Weekend #${weekends.MENS.number}`}
+                                {formatWeekendTitle(weekends.MENS, {
+                                  genderStyle: 'possessive',
+                                })}
                               </SelectItem>
                             )}
                             {!isNil(weekends?.WOMENS) && (
                               <SelectItem value={weekends.WOMENS.id}>
-                                Women&apos;s Weekend -{' '}
-                                {weekends.WOMENS.title ??
-                                  `Weekend #${weekends.WOMENS.number}`}
+                                {formatWeekendTitle(weekends.WOMENS, {
+                                  genderStyle: 'possessive',
+                                })}
                               </SelectItem>
                             )}
                             {isNil(weekends?.MENS) &&

--- a/app/(public)/team-forms/info-sheet/page.tsx
+++ b/app/(public)/team-forms/info-sheet/page.tsx
@@ -4,7 +4,7 @@ import { TeamInfoForm } from '@/components/team-forms/team-info-form'
 import { isErr, unwrap } from '@/lib/results'
 import { isNil } from 'lodash'
 import { getUserServiceHistory } from '@/actions/user-experience'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
+import { parseCommunityWeekendRef } from '@/lib/weekend/weekend-reference'
 import { experienceToFormValues } from '@/lib/users/experience'
 import { getUserMedicalProfile } from '@/services/weekend-group-member/weekend-group-member-service'
 
@@ -38,21 +38,19 @@ export default async function TeamInfoPage() {
   const experience = experienceToFormValues(
     unwrap(serviceHistoryResult).experience
   )
-  const attendedWeekendReference = !isNil(
+  const attendedWeekendRef = parseCommunityWeekendRef(
     user.communityInformation.weekendAttended
   )
-    ? WeekendReference.fromString(
-        user.communityInformation.weekendAttended
-      ).toJSON()
-    : null
 
   const basicInfo = {
     church_affiliation: user.communityInformation.churchAffiliation ?? '',
-    weekend_attended: attendedWeekendReference ?? {
-      community: '',
-      weekend_number: '',
+    weekend_attended: {
+      community: attendedWeekendRef?.community ?? '',
+      weekend_number: attendedWeekendRef?.number.toString() ?? '',
     },
-    essentials_training_date: !isNil(user.communityInformation.essentialsTrainingDate)
+    essentials_training_date: !isNil(
+      user.communityInformation.essentialsTrainingDate
+    )
       ? new Date(user.communityInformation.essentialsTrainingDate)
       : undefined,
     special_gifts_and_skills:

--- a/app/admin/payments/summary/hooks/use-payment-report.ts
+++ b/app/admin/payments/summary/hooks/use-payment-report.ts
@@ -1,7 +1,13 @@
 import { useMemo, useState } from 'react'
+import { isNil } from 'lodash'
 import type { PaymentTransactionDTO } from '@/services/payment'
 import { computeWeekendReport } from '@/lib/payments/compute-totals'
 import type { WeekendGroup } from '@/lib/payments/compute-totals'
+import {
+  formatWeekendGroupLabel,
+  NO_WEEKEND_GROUP_LABEL,
+} from '@/lib/payments/formatters'
+import { formatWeekendGroupTitle } from '@/lib/weekend'
 
 export type UsePaymentReportReturn = {
   weekendGroupOptions: string[]
@@ -14,20 +20,27 @@ export function usePaymentReport(
   payments: PaymentTransactionDTO[]
 ): UsePaymentReportReturn {
   const weekendGroupOptions = useMemo(() => {
-    const labels = new Set<string>()
+    // Sort on the number, not the label — otherwise "#10" sorts before "#9".
+    const numbers = new Set<number | null>()
     for (const p of payments) {
-      labels.add(p.weekend_title ?? 'No Weekend')
+      numbers.add(p.weekend_number)
     }
-    return [...labels].sort()
+    return [...numbers]
+      .sort((a, b) => {
+        if (isNil(a)) return 1
+        if (isNil(b)) return -1
+        return b - a
+      })
+      .map((number) =>
+        isNil(number) ? NO_WEEKEND_GROUP_LABEL : formatWeekendGroupTitle(number)
+      )
   }, [payments])
 
   const [selectedGroup, setSelectedGroup] = useState<string>('all')
 
   const filteredPayments = useMemo(() => {
     if (selectedGroup === 'all') return payments
-    return payments.filter(
-      (p) => (p.weekend_title ?? 'No Weekend') === selectedGroup
-    )
+    return payments.filter((p) => formatWeekendGroupLabel(p) === selectedGroup)
   }, [payments, selectedGroup])
 
   const report = useMemo(

--- a/app/admin/users/hooks/use-user-edit-form.ts
+++ b/app/admin/users/hooks/use-user-edit-form.ts
@@ -6,7 +6,7 @@ import { isNil, isEqual } from 'lodash'
 import { toast } from 'sonner'
 import { isErr } from '@/lib/results'
 import { formatPhoneNumber } from '@/lib/utils'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
+import { parseCommunityWeekendRef } from '@/lib/weekend/weekend-reference'
 import { groupExperienceByCommunity } from '@/lib/users/experience'
 import { updateUserRoles } from '@/services/identity/roles'
 import {
@@ -115,16 +115,12 @@ export function useUserEditForm({
 
     let weekendCommunity = ''
     let weekendNumber = ''
-    if (!isNil(member.communityInformation.weekendAttended)) {
-      try {
-        const ref = WeekendReference.fromString(
-          member.communityInformation.weekendAttended
-        )
-        weekendCommunity = ref.community
-        weekendNumber = ref.weekend_number.toString()
-      } catch {
-        // ignore parse errors
-      }
+    const attendedRef = parseCommunityWeekendRef(
+      member.communityInformation.weekendAttended
+    )
+    if (!isNil(attendedRef)) {
+      weekendCommunity = attendedRef.community
+      weekendNumber = attendedRef.number.toString()
     }
 
     setCommunity({

--- a/app/admin/weekends/[weekend_id]/page.tsx
+++ b/app/admin/weekends/[weekend_id]/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation'
 import { WeekendRosterView } from '@/components/weekend'
 import { getLoggedInUser } from '@/services/identity/user'
 import { getWeekendById } from '@/services/weekend'
-import { isNil } from 'lodash'
+import { formatWeekendTitle } from '@/lib/weekend'
 
 type WeekendDetailPageProps = {
   params: Promise<{ weekend_id: string }>
@@ -25,10 +25,7 @@ export default async function WeekendDetailPage({
   // Fetch weekend info for breadcrumb title
   const weekendResult = await getWeekendById(weekend_id)
   const weekendTitle = !isErr(weekendResult)
-    ? (weekendResult.data.title ??
-      (!isNil(weekendResult.data.number)
-        ? `Group ${weekendResult.data.number} — ${weekendResult.data.type === 'MENS' ? "Men's" : "Women's"}`
-        : `${weekendResult.data.type} Weekend`))
+    ? formatWeekendTitle(weekendResult.data)
     : 'Weekend'
 
   return (

--- a/app/admin/weekends/components/SetActiveWeekendButton.tsx
+++ b/app/admin/weekends/components/SetActiveWeekendButton.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import type { WeekendGroupWithId } from '@/lib/weekend/types'
 import { WeekendStatus } from '@/lib/weekend/types'
-import { getGroupStatus } from '@/lib/weekend'
+import { formatWeekendGroupTitle, getGroupStatus } from '@/lib/weekend'
 import { setActiveWeekendGroup } from '@/services/weekend'
 import { isErr } from '@/lib/results'
 import { toast } from 'sonner'
@@ -79,10 +79,9 @@ export function SetActiveWeekendButton({
       }
 
       const selectedGroup = weekendGroups.find((g) => g.groupId === groupId)
-      const title =
-        selectedGroup?.weekends.MENS?.title
-          ?.replace(/mens|womens/gi, '')
-          .trim() ?? 'Weekend'
+      const title = !isNil(selectedGroup)
+        ? formatGroupTitle(selectedGroup)
+        : 'Weekend'
 
       toast.success('Active weekend updated', {
         description: `${title} is now the active weekend`,
@@ -98,9 +97,8 @@ export function SetActiveWeekendButton({
   }
 
   const formatGroupTitle = (group: WeekendGroupWithId): string => {
-    return (
-      group.weekends.MENS?.title?.replace(/mens|womens/gi, '').trim() ??
-      `Weekend #${group.weekends.MENS?.number ?? group.weekends.WOMENS?.number ?? '?'}`
+    return formatWeekendGroupTitle(
+      group.weekends.MENS?.number ?? group.weekends.WOMENS?.number
     )
   }
 

--- a/app/admin/weekends/components/WeekendGroupContainer.tsx
+++ b/app/admin/weekends/components/WeekendGroupContainer.tsx
@@ -7,7 +7,7 @@ import { Typography } from '@/components/ui/typography'
 import type { WeekendGroupWithId } from '@/lib/weekend/types'
 import { WeekendCard } from './WeekendCard'
 import { WeekendStatusBadge } from '@/components/weekend/WeekendStatusBadge'
-import { getGroupStatus } from '@/lib/weekend'
+import { formatWeekendGroupTitle, getGroupStatus } from '@/lib/weekend'
 import { isNil } from 'lodash'
 
 interface WeekendGroupContainerProps {
@@ -22,7 +22,9 @@ export function WeekendGroupContainer({
   onEdit,
 }: WeekendGroupContainerProps) {
   const { MENS, WOMENS } = group.weekends
-  const groupTitle = group.weekends.MENS?.title?.replace(/mens|womens/gi, '')
+  const groupTitle = formatWeekendGroupTitle(
+    group.weekends.MENS?.number ?? group.weekends.WOMENS?.number
+  )
   const groupStatus = getGroupStatus(group)
 
   return (

--- a/app/admin/weekends/components/WeekendSidebar.tsx
+++ b/app/admin/weekends/components/WeekendSidebar.tsx
@@ -35,8 +35,7 @@ import {
 import { isErr } from '@/lib/results'
 import { toast } from 'sonner'
 import { toastError } from '@/lib/toast-error'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
-import { COMMUNITY_NAME } from '@/lib/weekend/constants'
+import { formatWeekendGroupTitle } from '@/lib/weekend'
 import type { DateRange } from '@/lib/weekend/scheduling'
 import {
   addDays,
@@ -86,7 +85,7 @@ export function WeekendSidebar({
 
   const weekendLabel = useMemo(() => {
     const number = weekendGroup?.weekends.MENS?.number ?? nextGroupNumber
-    return new WeekendReference(COMMUNITY_NAME, number).toString()
+    return formatWeekendGroupTitle(number)
   }, [weekendGroup, nextGroupNumber])
 
   // Form state managed by React Hook Form

--- a/components/current-weekend/CurrentWeekendHeader.tsx
+++ b/components/current-weekend/CurrentWeekendHeader.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns'
 import type { Weekend } from '@/lib/weekend/types'
-import { trimWeekendTypeFromTitle, formatWeekendTitle } from '@/lib/weekend'
+import { formatWeekendGroupTitle } from '@/lib/weekend'
 import { Typography } from '@/components/ui/typography'
 
 interface CurrentWeekendHeaderProps {
@@ -14,17 +14,14 @@ function formatDateRange(startDate: string, endDate: string): string {
   return `${format(start, 'MMM d')} - ${format(end, 'MMM d')}`
 }
 
-function getWeekendGroupTitle(weekend: Weekend): string {
-  const title = formatWeekendTitle(weekend)
-  return trimWeekendTypeFromTitle(title).trim()
-}
-
 export function CurrentWeekendHeader({
   mensWeekend,
   womensWeekend,
 }: CurrentWeekendHeaderProps) {
-  // Use the weekend title from either weekend (they share the same group title like "DTTD #11")
-  const groupTitle = getWeekendGroupTitle(mensWeekend)
+  // Both weekends share one group title, e.g. "DTTD #11"
+  const groupTitle = formatWeekendGroupTitle(
+    mensWeekend.number ?? womensWeekend.number
+  )
 
   return (
     <div className="space-y-4">

--- a/components/weekend/weekend-roster-view.tsx
+++ b/components/weekend/weekend-roster-view.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link'
 import { Users } from 'lucide-react'
 import { isNil } from 'lodash'
 import { WeekendStatus } from '@/lib/weekend/types'
+import { formatWeekendTitle } from '@/lib/weekend'
 import { getWeekendRosterViewData } from '@/services/weekend'
 import { Permission, userHasPermission } from '@/lib/security'
 import type { User } from '@/lib/users/types'
@@ -74,8 +75,7 @@ export async function WeekendRosterView({
 
   const startDate = formatDateOnly(weekend.start_date)
   const endDate = formatDateOnly(weekend.end_date)
-  const weekendTitle =
-    weekend.title ?? `${weekend.type} Weekend #${weekend.number}`
+  const weekendTitle = formatWeekendTitle(weekend)
 
   return (
     <>

--- a/lib/payments/compute-totals.ts
+++ b/lib/payments/compute-totals.ts
@@ -1,5 +1,7 @@
 import type { PaymentTransactionDTO } from '@/services/payment'
 import { isNil } from 'lodash'
+import { formatWeekendGroupTitle } from '@/lib/weekend'
+import { NO_WEEKEND_GROUP_LABEL } from './formatters'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -100,11 +102,16 @@ export type WeekendGroup = {
 export function computeWeekendReport(
   payments: PaymentTransactionDTO[]
 ): WeekendGroup[] {
-  // Group by weekend_title, then by weekend_type
-  const weekendMap = new Map<string, Map<string, PaymentTransactionDTO[]>>()
+  // Group by weekend group number, then by weekend_type. Keying on the number
+  // (rather than a display label) keeps Men's and Women's payments for the same
+  // weekend group together no matter how the label is formatted.
+  const weekendMap = new Map<
+    number | null,
+    Map<string, PaymentTransactionDTO[]>
+  >()
 
   for (const p of payments) {
-    const groupKey = p.weekend_title ?? 'No Weekend'
+    const groupKey = p.weekend_number
     const typeKey = p.weekend_type ?? 'unknown'
 
     if (!weekendMap.has(groupKey)) {
@@ -119,7 +126,18 @@ export function computeWeekendReport(
 
   const groups: WeekendGroup[] = []
 
-  for (const [groupLabel, typeMap] of weekendMap) {
+  // Newest weekend first; payments with no weekend sort last.
+  const sortedGroupKeys = [...weekendMap.keys()].sort((a, b) => {
+    if (isNil(a)) return 1
+    if (isNil(b)) return -1
+    return b - a
+  })
+
+  for (const groupKey of sortedGroupKeys) {
+    const typeMap = weekendMap.get(groupKey)!
+    const groupLabel = isNil(groupKey)
+      ? NO_WEEKEND_GROUP_LABEL
+      : formatWeekendGroupTitle(groupKey)
     const weekends: WeekendBreakdown[] = []
 
     // Sort: MENS first, then WOMENS, then unknown

--- a/lib/payments/formatters.ts
+++ b/lib/payments/formatters.ts
@@ -1,4 +1,9 @@
+import { isNil } from 'lodash'
 import type { PaymentTransactionDTO } from '@/services/payment'
+import { formatWeekendGroupTitle, formatWeekendLabelFor } from '@/lib/weekend'
+
+/** Bucket label for payments not attached to any weekend. */
+export const NO_WEEKEND_GROUP_LABEL = 'No Weekend'
 
 /**
  * Format a number as USD currency. Returns '—' for null values.
@@ -48,20 +53,25 @@ export function formatPaymentMethod(
 
 /**
  * Build a display label for a payment's associated weekend.
- * e.g. "DTTD Mens #45 — Men's" or "Unknown"
+ * e.g. "DTTD Mens #45", or "Unknown" when the payment has no weekend.
  */
 export function formatWeekendLabel(payment: PaymentTransactionDTO): string {
-  if (payment.weekend_title === null && payment.weekend_type === null)
-    return 'Unknown'
-  const type =
-    payment.weekend_type === 'MENS'
-      ? "Men's"
-      : payment.weekend_type === 'WOMENS'
-        ? "Women's"
-        : ''
-  return payment.weekend_title !== null
-    ? `${payment.weekend_title} — ${type}`
-    : type
+  const { weekend_number: number, weekend_type: gender } = payment
+
+  if (isNil(number) && isNil(gender)) return 'Unknown'
+
+  return formatWeekendLabelFor({ number, gender })
+}
+
+/**
+ * Build the group-level label a payment rolls up under, e.g. "DTTD #45".
+ * Men's and Women's payments for the same weekend group share this label.
+ */
+export function formatWeekendGroupLabel(
+  payment: PaymentTransactionDTO
+): string {
+  if (isNil(payment.weekend_number)) return NO_WEEKEND_GROUP_LABEL
+  return formatWeekendGroupTitle(payment.weekend_number)
 }
 
 /**

--- a/lib/users/experience/calculations.ts
+++ b/lib/users/experience/calculations.ts
@@ -10,7 +10,7 @@ import type {
   UserExperienceRecord,
 } from '@/services/master-roster/types'
 import type { UserExperience } from './validation'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
+import { parseCommunityWeekendRef } from '@/lib/weekend/weekend-reference'
 
 const DTTD_COMMUNITY = 'DTTD'
 
@@ -53,8 +53,8 @@ export function calculateRectorReadyStatus(
 ): RectorReadyStatus {
   const hasServedAsRector = records.some((r) => {
     if (r.cha_role !== CHARole.RECTOR) return false
-    const { community } = WeekendReference.fromString(r.weekend_reference)
-    return community === DTTD_COMMUNITY
+    const ref = parseCommunityWeekendRef(r.weekend_reference)
+    return ref?.community === DTTD_COMMUNITY
   })
 
   const criteria: RectorReadyCriteria = {
@@ -96,8 +96,11 @@ export function groupExperienceByCommunity(
 
   // Group by community name
   const grouped = groupBy(sortedRecords, (r) => {
-    const { community } = WeekendReference.fromString(r.weekend_reference)
-    return community
+    // Unparseable references group under their raw value rather than vanishing.
+    return (
+      parseCommunityWeekendRef(r.weekend_reference)?.community ??
+      r.weekend_reference
+    )
   })
 
   // Transform to output format

--- a/lib/users/experience/helpers.ts
+++ b/lib/users/experience/helpers.ts
@@ -1,5 +1,5 @@
 import type { UserExperienceFormValue } from '@/components/team-forms/schemas'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
+import { parseCommunityWeekendRef } from '@/lib/weekend/weekend-reference'
 import type { UserExperience } from './validation'
 
 /**
@@ -9,15 +9,13 @@ export const experienceToFormValues = (
   experience: Array<UserExperience>
 ): Array<UserExperienceFormValue> => {
   return experience.map((experience) => {
-    const { community, weekend_number } = WeekendReference.fromString(
-      experience.weekend_reference
-    )
+    const ref = parseCommunityWeekendRef(experience.weekend_reference)
     return {
       id: experience.id,
       cha_role: experience.cha_role,
       rollo: experience.rollo,
-      community,
-      weekend_number: weekend_number.toString(),
+      community: ref?.community ?? '',
+      weekend_number: ref?.number.toString() ?? '',
     }
   })
 }

--- a/lib/weekend/index.ts
+++ b/lib/weekend/index.ts
@@ -1,8 +1,34 @@
 import { isNil } from 'lodash'
-import { capitalize } from '@/lib/utils'
-import type { Weekend, WeekendGroupWithId, WeekendStatusValue } from './types'
-import type { TeamMemberInfo } from './types'
-import { COMMUNITY_NAME } from './constants'
+import type { WeekendGroupWithId, WeekendStatusValue } from './types'
+import type { TeamMemberInfo, WeekendType } from './types'
+import {
+  formatWeekendGender,
+  formatWeekendGroupTitle,
+  getWeekendLabel,
+} from './labels'
+import { toWeekendRef } from './weekend-reference'
+
+export {
+  formatWeekendGender,
+  formatWeekendGroupTitle,
+  formatWeekendLabelFor,
+  formatWeekendTitle,
+  getWeekendLabel,
+} from './labels'
+export type { WeekendGenderStyle, WeekendLabelOptions } from './labels'
+export type {
+  AnyWeekendRef,
+  CommunityWeekendRef,
+  WeekendRef,
+} from './weekend-reference'
+export {
+  formatCommunityWeekendRef,
+  isWeekendRef,
+  parseCommunityWeekendRef,
+  toCommunityWeekendRef,
+  toWeekendRef,
+  weekendToRef,
+} from './weekend-reference'
 
 export const genderMatchesWeekend = (
   gender: string | null,
@@ -15,22 +41,6 @@ export const genderMatchesWeekend = (
   )
 }
 
-export const trimWeekendTypeFromTitle = (title: string) => {
-  return title.replace(/mens|Mens|Womens|womens/g, '')
-}
-
-export const formatWeekendTitle = (weekend: Weekend) => {
-  const weekendTypeLabel = capitalize(weekend.type.toLowerCase())
-  if (!isNil(weekend.title)) {
-    // Remove mens or womens if it's in the weekend title already so that we can add it at the beginning consistently.
-    const reducedTitle = trimWeekendTypeFromTitle(weekend.title)
-    return `${weekendTypeLabel} ${reducedTitle}`
-  }
-
-  const numberSuffix = !isNil(weekend.number) ? ` #${weekend.number}` : ''
-  return `${weekendTypeLabel}${numberSuffix}`
-}
-
 // Get the status of a weekend group (both MENS and WOMENS should have same status)
 export const getGroupStatus = (
   group: WeekendGroupWithId
@@ -40,22 +50,23 @@ export const getGroupStatus = (
 
 /**
  * Formats a display title for team forms based on the group's weekend assignments.
- * - Single assignment: e.g., "Mens DTTD #11"
+ * - Single assignment: e.g., "DTTD Mens #11"
  * - Multiple assignments: e.g., "DTTD #11" (covers both weekends)
  */
 export function formatTeamMemberTitle(teamMemberInfo: TeamMemberInfo): string {
   const { groupNumber, weekendAssignments } = teamMemberInfo
-  const numberStr = !isNil(groupNumber) ? ` #${groupNumber}` : ''
 
-  if (weekendAssignments.length === 1) {
-    const type = weekendAssignments[0].weekendType
-    const typeLabel = !isNil(type) ? capitalize(type.toLowerCase()) : null
-    return !isNil(typeLabel)
-      ? `${typeLabel} ${COMMUNITY_NAME}${numberStr}`
-      : `${COMMUNITY_NAME}${numberStr}`
+  // A volunteer serving both weekends is covered by the group-level label.
+  const gender =
+    weekendAssignments.length === 1
+      ? (weekendAssignments[0].weekendType as WeekendType | null)
+      : null
+
+  if (isNil(groupNumber) || isNil(gender)) {
+    return formatWeekendGroupTitle(groupNumber)
   }
 
-  return `${COMMUNITY_NAME}${numberStr}`
+  return getWeekendLabel(toWeekendRef({ number: groupNumber, gender }))
 }
 
 /**
@@ -80,9 +91,7 @@ export function formatTeamMemberRole(teamMemberInfo: TeamMemberInfo): string {
 
   return weekendAssignments
     .map((a) => {
-      const typeLabel = !isNil(a.weekendType)
-        ? capitalize(a.weekendType.toLowerCase())
-        : null
+      const typeLabel = formatWeekendGender(a.weekendType as WeekendType | null)
       const suffix = !isNil(typeLabel) ? ` (${typeLabel})` : ''
       return `${a.chaRole ?? 'Team Member'}${suffix}`
     })

--- a/lib/weekend/labels.test.ts
+++ b/lib/weekend/labels.test.ts
@@ -1,0 +1,157 @@
+import {
+  formatWeekendGender,
+  formatWeekendGroupTitle,
+  formatWeekendLabelFor,
+  formatWeekendTitle,
+  getWeekendLabel,
+} from './labels'
+import {
+  formatCommunityWeekendRef,
+  parseCommunityWeekendRef,
+  toCommunityWeekendRef,
+  toWeekendRef,
+  weekendToRef,
+} from './weekend-reference'
+import type { Weekend } from './types'
+import { WeekendStatus, WeekendType } from './types'
+
+function makeWeekend(overrides: Partial<Weekend> = {}): Weekend {
+  return {
+    id: 'weekend-id',
+    start_date: '2026-03-12',
+    end_date: '2026-03-15',
+    number: 12,
+    status: WeekendStatus.PLANNING,
+    title: null,
+    type: WeekendType.MENS,
+    groupId: 'group-id',
+    ...overrides,
+  }
+}
+
+describe('getWeekendLabel', () => {
+  it('renders a qualified ref as "DTTD Mens #12"', () => {
+    const ref = toWeekendRef({ number: 12, gender: WeekendType.MENS })
+    expect(getWeekendLabel(ref)).toBe('DTTD Mens #12')
+  })
+
+  it('renders a womens weekend', () => {
+    const ref = toWeekendRef({ number: 12, gender: WeekendType.WOMENS })
+    expect(getWeekendLabel(ref)).toBe('DTTD Womens #12')
+  })
+
+  it('omits gender for a community-only ref', () => {
+    const ref = toCommunityWeekendRef({ number: 11 })
+    expect(getWeekendLabel(ref)).toBe('DTTD #11')
+  })
+
+  it('omits gender on request', () => {
+    const ref = toWeekendRef({ number: 12, gender: WeekendType.MENS })
+    expect(getWeekendLabel(ref, { includeGender: false })).toBe('DTTD #12')
+  })
+
+  it('supports the possessive style for prose', () => {
+    const ref = toWeekendRef({ number: 12, gender: WeekendType.WOMENS })
+    expect(getWeekendLabel(ref, { genderStyle: 'possessive' })).toBe(
+      "DTTD Women's #12"
+    )
+  })
+
+  it('honors a non-default community', () => {
+    const ref = toWeekendRef({
+      community: 'CHTD',
+      number: 3,
+      gender: WeekendType.MENS,
+    })
+    expect(getWeekendLabel(ref)).toBe('CHTD Mens #3')
+  })
+})
+
+describe('formatWeekendTitle', () => {
+  it('derives the label from the weekend record, ignoring any stored title', () => {
+    const weekend = makeWeekend({ title: 'Mens DTTD#12' })
+    expect(formatWeekendTitle(weekend)).toBe('DTTD Mens #12')
+  })
+
+  it('degrades gracefully when the weekend has no group number', () => {
+    const weekend = makeWeekend({ number: null, groupId: null })
+    expect(formatWeekendTitle(weekend)).toBe('DTTD Mens')
+  })
+})
+
+describe('formatWeekendGroupTitle', () => {
+  it('renders the group label without gender', () => {
+    expect(formatWeekendGroupTitle(12)).toBe('DTTD #12')
+  })
+
+  it('falls back to the community when there is no number', () => {
+    expect(formatWeekendGroupTitle(null)).toBe('DTTD')
+  })
+})
+
+describe('formatWeekendLabelFor', () => {
+  it('builds a full label from join-shaped parts', () => {
+    expect(
+      formatWeekendLabelFor({ number: 45, gender: WeekendType.WOMENS })
+    ).toBe('DTTD Womens #45')
+  })
+
+  it('drops the gender segment when it is unknown', () => {
+    expect(formatWeekendLabelFor({ number: 45, gender: null })).toBe('DTTD #45')
+  })
+
+  it('drops the number segment when it is unknown', () => {
+    expect(
+      formatWeekendLabelFor({ number: null, gender: WeekendType.MENS })
+    ).toBe('DTTD Mens')
+  })
+})
+
+describe('formatWeekendGender', () => {
+  it('renders both styles', () => {
+    expect(formatWeekendGender(WeekendType.MENS)).toBe('Mens')
+    expect(formatWeekendGender(WeekendType.MENS, 'possessive')).toBe("Men's")
+  })
+
+  it('returns null when the gender is unknown', () => {
+    expect(formatWeekendGender(null)).toBeNull()
+  })
+})
+
+describe('community weekend ref encoding', () => {
+  it('round-trips the persisted DTTD#11 format', () => {
+    const ref = toCommunityWeekendRef({ number: 11 })
+    const encoded = formatCommunityWeekendRef(ref)
+
+    expect(encoded).toBe('DTTD#11')
+    expect(parseCommunityWeekendRef(encoded)).toEqual(ref)
+  })
+
+  it('keeps the wire format distinct from the display label', () => {
+    const ref = toWeekendRef({ number: 11, gender: WeekendType.MENS })
+
+    expect(formatCommunityWeekendRef(ref)).toBe('DTTD#11')
+    expect(getWeekendLabel(ref)).toBe('DTTD Mens #11')
+  })
+
+  it('returns null rather than NaN for unparseable input', () => {
+    expect(parseCommunityWeekendRef('nonsense')).toBeNull()
+    expect(parseCommunityWeekendRef('DTTD#')).toBeNull()
+    expect(parseCommunityWeekendRef('#11')).toBeNull()
+    expect(parseCommunityWeekendRef(null)).toBeNull()
+  })
+})
+
+describe('weekendToRef', () => {
+  it('builds a qualified ref from a weekend record', () => {
+    expect(weekendToRef(makeWeekend())).toEqual({
+      community: 'DTTD',
+      number: 12,
+      gender: WeekendType.MENS,
+    })
+  })
+
+  it('returns null when the weekend has no number to identify it', () => {
+    expect(weekendToRef(makeWeekend({ number: null }))).toBeNull()
+  })
+})

--- a/lib/weekend/labels.ts
+++ b/lib/weekend/labels.ts
@@ -1,0 +1,133 @@
+import { isNil } from 'lodash'
+import type { Weekend } from './types'
+import { WeekendType } from './types'
+import { COMMUNITY_NAME } from './constants'
+import type { AnyWeekendRef } from './weekend-reference'
+import { isWeekendRef, weekendToRef } from './weekend-reference'
+
+/**
+ * How the gender segment of a weekend label is rendered.
+ * - `short`: "Mens" / "Womens" — the canonical form used in weekend labels.
+ * - `possessive`: "Men's" / "Women's" — for prose where the label isn't the subject.
+ */
+export type WeekendGenderStyle = 'short' | 'possessive'
+
+export type WeekendLabelOptions = {
+  /**
+   * Include the gender segment. Defaults to true whenever the ref has one.
+   * Set false for group-level labels that cover both weekends.
+   */
+  includeGender?: boolean
+  /** Defaults to `short`. */
+  genderStyle?: WeekendGenderStyle
+}
+
+const GENDER_LABELS: Record<WeekendType, Record<WeekendGenderStyle, string>> = {
+  [WeekendType.MENS]: { short: 'Mens', possessive: "Men's" },
+  [WeekendType.WOMENS]: { short: 'Womens', possessive: "Women's" },
+}
+
+/**
+ * Renders just the gender segment, e.g. "Mens" or "Men's".
+ * Returns null when the gender is unknown so callers can omit the segment.
+ */
+export function formatWeekendGender(
+  gender: WeekendType | null | undefined,
+  style: WeekendGenderStyle = 'short'
+): string | null {
+  if (isNil(gender)) return null
+  return GENDER_LABELS[gender]?.[style] ?? null
+}
+
+/**
+ * The single source of truth for how a weekend is labelled across the app.
+ *
+ * Takes a whole ref rather than loose parts, so changing the format is a
+ * one-file change no matter how many places render a weekend.
+ *
+ * - `DTTD Mens #12` — a qualified {@link WeekendRef} (the default)
+ * - `DTTD #12`      — a {@link CommunityWeekendRef}, or `includeGender: false`
+ */
+export function getWeekendLabel(
+  ref: AnyWeekendRef,
+  options: WeekendLabelOptions = {}
+): string {
+  const { includeGender = true, genderStyle = 'short' } = options
+
+  const gender =
+    includeGender && isWeekendRef(ref)
+      ? formatWeekendGender(ref.gender, genderStyle)
+      : null
+
+  return [ref.community, gender, `#${ref.number}`]
+    .filter((segment): segment is string => !isNil(segment))
+    .join(' ')
+}
+
+/**
+ * Labels a weekend from whatever parts a caller happens to have — typically a
+ * join that carries the group number and type but nothing else.
+ *
+ * Prefer {@link getWeekendLabel} when you can build a real ref; this is the
+ * tolerant variant for partial data, degrading to "DTTD Mens" or "DTTD #12"
+ * rather than rendering a bogus number or an empty string.
+ */
+export function formatWeekendLabelFor(
+  parts: {
+    number: number | null | undefined
+    gender: WeekendType | null | undefined
+    community?: string
+  },
+  options: WeekendLabelOptions = {}
+): string {
+  const community = parts.community ?? COMMUNITY_NAME
+
+  if (!isNil(parts.number) && !isNil(parts.gender)) {
+    return getWeekendLabel(
+      { community, number: parts.number, gender: parts.gender },
+      options
+    )
+  }
+
+  if (!isNil(parts.number)) {
+    return formatWeekendGroupTitle(parts.number, community)
+  }
+
+  const gender =
+    options.includeGender === false
+      ? null
+      : formatWeekendGender(parts.gender, options.genderStyle)
+
+  return [community, gender]
+    .filter((segment): segment is string => !isNil(segment))
+    .join(' ')
+}
+
+/**
+ * Labels a weekend record, deriving every segment from its own fields.
+ * e.g. "DTTD Mens #12"
+ */
+export function formatWeekendTitle(
+  weekend: Weekend,
+  options?: WeekendLabelOptions
+): string {
+  const ref = weekendToRef(weekend)
+  if (!isNil(ref)) return getWeekendLabel(ref, options)
+
+  return formatWeekendLabelFor(
+    { number: weekend.number, gender: weekend.type },
+    options
+  )
+}
+
+/**
+ * Labels the weekend group a weekend belongs to — the same format minus the
+ * gender segment, since a group covers both weekends. e.g. "DTTD #12"
+ */
+export function formatWeekendGroupTitle(
+  number: number | null | undefined,
+  community: string = COMMUNITY_NAME
+): string {
+  if (isNil(number)) return community
+  return getWeekendLabel({ community, number })
+}

--- a/lib/weekend/scheduling.ts
+++ b/lib/weekend/scheduling.ts
@@ -155,13 +155,5 @@ export const getWeekendTitle = (weekend: Weekend | null) => {
     return ''
   }
 
-  if (!isNil(weekend.title)) {
-    return formatWeekendTitle(weekend)
-  }
-
-  if (typeof weekend.number === 'number') {
-    return `Weekend #${weekend.number}`
-  }
-
-  return ''
+  return formatWeekendTitle(weekend)
 }

--- a/lib/weekend/types.ts
+++ b/lib/weekend/types.ts
@@ -90,7 +90,6 @@ export type WeekendWriteInput = {
   start_date: string
   end_date: string
   status?: WeekendStatusValue | null
-  title?: string | null
 }
 
 export type WeekendUpdateInput = Partial<WeekendWriteInput>

--- a/lib/weekend/weekend-reference.ts
+++ b/lib/weekend/weekend-reference.ts
@@ -1,28 +1,109 @@
+import { isNil } from 'lodash'
+import type { Weekend, WeekendType } from './types'
+import { COMMUNITY_NAME } from './constants'
+
 /**
- * Used to help stringify a reference to a weekend to store in the DB
+ * A weekend as the outside world names it: a community and a number, nothing
+ * more. This is deliberately under-specified — it cannot tell you which of the
+ * two gendered weekends is meant, and it is not tied to a row in our database.
+ *
+ * Use it for weekends we don't own: an attendee's "I walked DTTD #11", or a
+ * visitor's weekend from another community. This is the shape persisted in
+ * `users_experience.weekend_reference` and `users.weekend_attended` as the
+ * string `DTTD#11` — that encoding is on disk, so {@link formatCommunityWeekendRef}
+ * and {@link parseCommunityWeekendRef} must stay in sync and must not be
+ * repurposed for display.
  */
-export class WeekendReference {
+export type CommunityWeekendRef = {
   community: string
-  weekend_number: number
+  number: number
+}
 
-  constructor(community: string, weekend_number: number) {
-    this.community = community
-    this.weekend_number = weekend_number
-  }
+/**
+ * A weekend in our system, fully identified. Every field is required: if you
+ * can't say which gender it is, you have a {@link CommunityWeekendRef}, not
+ * one of these.
+ *
+ * This is an *identity*, not the record — dates, status and id live on
+ * {@link Weekend}. Build one with {@link toWeekendRef} and render it with
+ * `getWeekendLabel` from `./labels`.
+ */
+export type WeekendRef = CommunityWeekendRef & {
+  gender: WeekendType
+}
 
-  static fromString(weekendReferenceString: string): WeekendReference {
-    const [community, weekendNumber] = weekendReferenceString.split('#')
-    return new WeekendReference(community, parseInt(weekendNumber))
-  }
+export type AnyWeekendRef = CommunityWeekendRef | WeekendRef
 
-  toString(): string {
-    return `${this.community}#${this.weekend_number}`
-  }
+/** Narrows a ref to the fully-qualified kind. */
+export function isWeekendRef(ref: AnyWeekendRef): ref is WeekendRef {
+  return 'gender' in ref && !isNil(ref.gender)
+}
 
-  toJSON(): { community: string; weekend_number: string } {
-    return {
-      community: this.community,
-      weekend_number: this.weekend_number.toString(),
-    }
+export function toCommunityWeekendRef(input: {
+  community?: string
+  number: number
+}): CommunityWeekendRef {
+  return {
+    community: input.community ?? COMMUNITY_NAME,
+    number: input.number,
   }
+}
+
+export function toWeekendRef(input: {
+  community?: string
+  number: number
+  gender: WeekendType
+}): WeekendRef {
+  return {
+    community: input.community ?? COMMUNITY_NAME,
+    number: input.number,
+    gender: input.gender,
+  }
+}
+
+/**
+ * Builds a qualified ref from a weekend record. Returns null when the weekend
+ * is not attached to a numbered group, since a ref without a number cannot
+ * identify anything.
+ */
+export function weekendToRef(
+  weekend: Pick<Weekend, 'number' | 'type'>,
+  community: string = COMMUNITY_NAME
+): WeekendRef | null {
+  if (isNil(weekend.number)) return null
+  return toWeekendRef({
+    community,
+    number: weekend.number,
+    gender: weekend.type,
+  })
+}
+
+/**
+ * Encodes a community ref for storage, e.g. `DTTD#11`.
+ *
+ * This is a wire format, not a label. For anything a user reads, use
+ * `getWeekendLabel` from `./labels`.
+ */
+export function formatCommunityWeekendRef(ref: CommunityWeekendRef): string {
+  return `${ref.community}#${ref.number}`
+}
+
+/**
+ * Decodes a stored `DTTD#11` string. Returns null for anything unparseable so
+ * callers handle bad data explicitly rather than propagating NaN.
+ */
+export function parseCommunityWeekendRef(
+  value: string | null | undefined
+): CommunityWeekendRef | null {
+  if (isNil(value)) return null
+
+  const [community, numberPart] = value.split('#')
+  const number = parseInt(numberPart)
+  if (isEmptyish(community) || Number.isNaN(number)) return null
+
+  return { community, number }
+}
+
+function isEmptyish(value: string | undefined): boolean {
+  return isNil(value) || value.trim() === ''
 }

--- a/services/identity/user/repository.ts
+++ b/services/identity/user/repository.ts
@@ -5,7 +5,10 @@ import { createClient } from '@/lib/supabase/server'
 import { err, fromSupabase, ok } from '@/lib/results'
 import type { Address } from '@/lib/users/validation'
 import type { BasicInfo } from '@/components/team-forms/schemas'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
+import {
+  formatCommunityWeekendRef,
+  toCommunityWeekendRef,
+} from '@/lib/weekend/weekend-reference'
 
 export const GetUserInfoQuery = `
   id,
@@ -199,10 +202,12 @@ export const updateUserContactInfo = async (
 export const updateUserBasicInfo = async (userId: string, data: BasicInfo) => {
   const supabase = await createClient()
 
-  const weekendAttendedStr = new WeekendReference(
-    data.weekend_attended.community,
-    parseInt(data.weekend_attended.weekend_number)
-  ).toString()
+  const weekendAttendedStr = formatCommunityWeekendRef(
+    toCommunityWeekendRef({
+      community: data.weekend_attended.community,
+      number: parseInt(data.weekend_attended.weekend_number),
+    })
+  )
 
   const response = await supabase
     .from('users')

--- a/services/notifications/email-actions.ts
+++ b/services/notifications/email-actions.ts
@@ -15,6 +15,7 @@ import { getHydratedCandidate } from '@/actions/candidates'
 import CandidateFeePaymentRequestEmail from '@/components/email/PaymentRequestEmail'
 import TeamPaymentNotificationEmail from '@/components/email/TeamPaymentNotificationEmail'
 import * as NotificationService from './notification-service'
+import { formatWeekendLabelFor } from '@/lib/weekend'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
@@ -248,7 +249,11 @@ export async function notifyAssistantHeadForTeamPayment(
           .single(),
 
         // Get weekend details
-        supabase.from('weekends').select('*').eq('id', weekendId).single(),
+        supabase
+          .from('weekends')
+          .select('*, weekend_groups(number)')
+          .eq('id', weekendId)
+          .single(),
 
         // Find Assistant Head for this weekend
         supabase
@@ -300,7 +305,10 @@ export async function notifyAssistantHeadForTeamPayment(
       react: TeamPaymentNotificationEmail({
         teamMemberName: `${teamMember.users.first_name} ${teamMember.users.last_name}`,
         teamMemberEmail: teamMember.users.email,
-        weekendName: weekend.title ?? `${weekend.type} DTTD`,
+        weekendName: formatWeekendLabelFor({
+          number: weekend.weekend_groups?.number,
+          gender: weekend.type,
+        }),
         paymentAmount,
       }),
     })

--- a/services/payment/payment-service.ts
+++ b/services/payment/payment-service.ts
@@ -141,7 +141,7 @@ function normalizePaymentTransaction(
     created_at: raw.created_at ?? new Date().toISOString(),
     payer_name: payerName,
     payer_email: null, // Email not stored in payment_transaction; would require separate lookup
-    weekend_title: raw.weekends?.title ?? null,
+    weekend_number: raw.weekends?.weekend_groups?.number ?? null,
     weekend_type: (raw.weekends?.type as 'MENS' | 'WOMENS') ?? null,
   }
 }

--- a/services/payment/repository.ts
+++ b/services/payment/repository.ts
@@ -53,7 +53,7 @@ export const PaymentTransactionQuery = `
   charge_id,
   balance_transaction_id,
   created_at,
-  weekends(title, type)
+  weekends(type, weekend_groups(number))
 `
 
 // ============================================================================

--- a/services/payment/types.ts
+++ b/services/payment/types.ts
@@ -179,7 +179,10 @@ export type RawPaymentTransaction = PaymentTransactionRow & {
  * Raw payment row with joined weekend data from getAllPayments query.
  */
 export type PaymentTransactionWithWeekend = PaymentTransactionRow & {
-  weekends: { title: string | null; type: string } | null
+  weekends: {
+    type: string
+    weekend_groups: { number: number | null } | null
+  } | null
 }
 
 // ============================================================================
@@ -208,7 +211,8 @@ export type PaymentTransactionDTO = {
   // Derived payer info
   payer_name: string | null
   payer_email: string | null
-  // Joined weekend info
-  weekend_title: string | null
+  // Joined weekend info. The display label is derived from these — see
+  // `formatWeekendLabel` in lib/payments/formatters.
+  weekend_number: number | null
   weekend_type: 'MENS' | 'WOMENS' | null
 }

--- a/services/weekend/repository.ts
+++ b/services/weekend/repository.ts
@@ -200,7 +200,6 @@ export async function insertWeekendGroup(
     start_date: string
     end_date: string
     status: WeekendStatusValue
-    title: string | null
   }>
 ): Promise<Result<string, RawWeekendRecord[]>> {
   const supabase = await createClient()

--- a/services/weekend/weekend-service.ts
+++ b/services/weekend/weekend-service.ts
@@ -8,7 +8,7 @@ import { Permission, userHasPermission } from '@/lib/security'
 import type { User } from '@/lib/users/types'
 import { getWeekendRosterExperienceDistribution } from '@/services/master-roster/master-roster-service'
 import type { ExperienceDistribution } from '@/services/master-roster/types'
-import { formatWeekendTitle, trimWeekendTypeFromTitle } from '@/lib/weekend'
+import { formatWeekendGroupTitle } from '@/lib/weekend'
 import { COMMUNITY_NAME } from '@/lib/weekend/constants'
 import { logger } from '@/lib/logger'
 import type { Tables } from '@/database.types'
@@ -24,7 +24,10 @@ import type {
   UpdateWeekendGroupInput,
 } from '@/lib/weekend/types'
 import { WeekendType, WeekendStatus } from '@/lib/weekend/types'
-import { WeekendReference } from '@/lib/weekend/weekend-reference'
+import {
+  formatCommunityWeekendRef,
+  toCommunityWeekendRef,
+} from '@/lib/weekend/weekend-reference'
 import type {
   RawWeekendRoster,
   PaymentRecord,
@@ -117,7 +120,6 @@ function prepareInsertPayload(
     start_date: payload.start_date,
     end_date: payload.end_date,
     status: payload.status ?? WeekendStatus.PLANNING,
-    title: payload.title ?? null,
   }
 }
 
@@ -141,13 +143,14 @@ function hasDefinedUpdateValues(payload: WeekendUpdateInput): boolean {
 }
 
 /**
- * Formats a weekend label for display.
+ * Formats a group-level label for display, e.g. "DTTD #12". Gender is omitted
+ * because these labels front selectors where gender is chosen separately.
  */
 function getWeekendLabel(weekend: Weekend | null): string {
   if (isNil(weekend)) {
     return 'Unknown Weekend'
   }
-  return trimWeekendTypeFromTitle(formatWeekendTitle(weekend))
+  return formatWeekendGroupTitle(weekend.number)
 }
 
 /**
@@ -337,10 +340,9 @@ export async function transitionWeekendGroupToFinished(
       continue
     }
 
-    const weekendRef = new WeekendReference(
-      COMMUNITY_NAME,
-      groupNumber
-    ).toString()
+    const weekendRef = formatCommunityWeekendRef(
+      toCommunityWeekendRef({ community: COMMUNITY_NAME, number: groupNumber })
+    )
 
     // Primary role
     if (!isNil(record.cha_role)) {
@@ -551,19 +553,8 @@ export async function createWeekendGroup(
     return groupNumber
   }
 
-  // Auto-generate titles if not provided
-  const groupTitle = new WeekendReference(
-    COMMUNITY_NAME,
-    groupNumber.data
-  ).toString()
-  const mensInput = {
-    ...input.mens,
-    title: input.mens.title ?? `Mens ${groupTitle}`,
-  }
-  const womensInput = {
-    ...input.womens,
-    title: input.womens.title ?? `Womens ${groupTitle}`,
-  }
+  // Labels are derived from the group number and weekend type at render time —
+  // nothing is stored. See `getWeekendLabel` in lib/weekend/labels.
 
   // Create the weekend_groups parent record first (FK dependency)
   const groupResult = await WeekendRepository.insertWeekendGroupRecord(
@@ -576,8 +567,8 @@ export async function createWeekendGroup(
 
   // Prepare and insert payloads
   const insertPayload = [
-    prepareInsertPayload(input.groupId, WeekendType.MENS, mensInput),
-    prepareInsertPayload(input.groupId, WeekendType.WOMENS, womensInput),
+    prepareInsertPayload(input.groupId, WeekendType.MENS, input.mens),
+    prepareInsertPayload(input.groupId, WeekendType.WOMENS, input.womens),
   ]
 
   const result = await WeekendRepository.insertWeekendGroup(insertPayload)


### PR DESCRIPTION
First of two stacked PRs. This one changes no schema — it stops reading and writing `weekends.title`. [#2 drops the column](https://github.com/sdavisde/dttd/pulls) and is stacked on this branch.

## Why

Weekend labels were stored as free text in `weekends.title`, written once at creation by `createWeekendGroup` and **never editable through the UI** — the admin weekend sidebar only edits dates. Three formats accumulated in the data:

| Origin | Stored title |
|---|---|
| Prod #11 (predates the auto-title code) | `DTTD#11` |
| Created through the app (#12) | `Mens DTTD#12` |
| `supabase/seed.sql` | `DTTD Mens #42` |

The display code papered over the difference by stripping the gender prefix back off with a regex (`trimWeekendTypeFromTitle`, plus two ad-hoc `.replace(/mens|womens/gi, '')` calls), which left artifacts:

- `formatWeekendTitle` returned `"Mens  DTTD#12"` — double space
- `getWeekendLabel` returned `"  DTTD#12"` — two leading spaces, never trimmed, and it feeds the candidate-list CSV **export filename**
- the admin weekend card rendered `" DTTD#12"`

The label is pure denormalized duplication of data we already store: `weekend_groups.number` and `weekends.type`. So derive it.

## The abstraction

Two distinct concepts replace the old `WeekendReference` class, as plain types with plain constructor functions:

```ts
type CommunityWeekendRef = { community: string; number: number }
type WeekendRef = CommunityWeekendRef & { gender: WeekendType }   // every field required
```

`CommunityWeekendRef` is deliberately under-specified: a weekend we don't own, like an attendee's "I walked DTTD #11". It's what `users_experience.weekend_reference` and `users.weekend_attended` persist as the string `DTTD#11`.

**That wire format is unchanged.** It's the one genuinely dangerous thing here — if the persisted encoding drifted, every stored row would fail to parse and silently corrupt experience counts. `formatCommunityWeekendRef` / `parseCommunityWeekendRef` keep it strictly separate from anything a user reads.

`WeekendRef` is a fully identified weekend in our system. It's an *identity*, not the record — dates, status and id stay on `Weekend`.

Rendering goes through one function, so changing the format is a one-file change:

```ts
getWeekendLabel(toWeekendRef({ number: 12, gender: 'MENS' }))                     // "DTTD Mens #12"
getWeekendLabel(ref, { includeGender: false })                                    // "DTTD #12"
getWeekendLabel(ref, { genderStyle: 'possessive' })                               // "DTTD Men's #12"
```

`formatWeekendLabelFor({ number, gender })` is the tolerant variant for join-shaped data where either part may be null (payments, the team-fee email, candidate move options). It degrades to `DTTD #12` or `DTTD Mens` rather than rendering a bogus number.

## Behavior changes

- **Payment summary rolls up correctly.** `computeWeekendReport` keyed on the raw title string, so `Mens DTTD#12` and `Womens DTTD#12` were two separate top-level groups while `DTTD#11` correctly collapsed into one. It now keys on the weekend group number, so Men's and Women's always group together with per-gender breakdown rows.
- **Weekend dropdowns sort on the number**, so `#10` no longer sorts before `#9`.
- **`parseCommunityWeekendRef` returns null** for unparseable input instead of propagating `NaN`.
- **The team-fee email joins the group number** so it can still name the weekend — previously it printed the raw title, which was the one place where dropping the prefix would have lost information.

⚠️ **The payments URL filter goes stale.** The `weekend` column filter stores formatted label strings in the URL. Any bookmarked or shared payments link carrying `weekend=Mens+DTTD%2312` will match zero rows after deploy. No data risk, fixed by re-picking the filter.

## Verification

`tsc --noEmit` clean · 83 tests pass (20 new in `lib/weekend/labels.test.ts`) · `yarn lint` clean (one pre-existing TanStack warning) · `yarn build` succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCx4YdQiaFiE2Ss7TP9q3L)_